### PR TITLE
validator: xml: add an idempotent CharsetReader

### DIFF
--- a/test/fixtures/good-utf16.xml
+++ b/test/fixtures/good-utf16.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-16"?>
+<do-not-complain-about-utf16>
+</do-not-complain-about-utf16>

--- a/test/fixtures/good.xml
+++ b/test/fixtures/good.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<good></good>


### PR DESCRIPTION
The CharsetReader does not do anything, but it avoids the library complaining when handling an UTF-16 file.

Added test files as regression tests. Without the change the error manifests as:

> test/fixtures/good-utf16.xml
> error: xml: encoding "utf-16" declared but Decoder.CharsetReader is nil